### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/mac-14.yml
+++ b/.github/workflows/mac-14.yml
@@ -8,6 +8,8 @@ jobs:
   build:
     name: mac-14
     runs-on: macos-14
+    permissions:
+      contents: read
     steps:
     - name: brew
       run: brew install macfuse


### PR DESCRIPTION
Potential fix for [https://github.com/hyoklee/h5f/security/code-scanning/7](https://github.com/hyoklee/h5f/security/code-scanning/7)

In general, the fix is to add an explicit `permissions` block to the workflow (either at the root level or per job) that grants only the minimal access the workflow needs. Since this workflow just installs a package, checks out the code, and runs `make`, it only needs read access to repository contents.

The best fix here is to add a job-level `permissions` block under `jobs.build` in `.github/workflows/mac-14.yml`, setting `contents: read`. This scopes the `GITHUB_TOKEN` used in the `build` job to read-only repository contents and leaves other permissions at their more restrictive defaults. No other functionality needs to change.

Concretely: in `.github/workflows/mac-14.yml`, under `jobs:  build:  name: mac-14`, insert:

```yml
    permissions:
      contents: read
```

with the correct indentation (2 spaces under `build:`). No imports or additional methods are needed because this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
