### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/flw.yml
+++ b/.github/workflows/flw.yml
@@ -1,4 +1,6 @@
 name: flw
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/hyoklee/h5f/security/code-scanning/1](https://github.com/hyoklee/h5f/security/code-scanning/1)

In general, the fix is to explicitly define `permissions` in the workflow (either at the root or per job) to restrict the `GITHUB_TOKEN` to the minimal scopes needed. For a build/test workflow that only needs to read repository contents, `contents: read` is usually sufficient.

For this specific workflow in `.github/workflows/flw.yml`, the job only checks out a repository and runs build/tests. It does not interact with issues, PRs, or push changes. The least-privilege configuration therefore is to add a `permissions:` block at the workflow root, directly under `name: flw`, with `contents: read`. This applies to all jobs, including `build`, without changing existing functionality. No additional imports, methods, or other definitions are required because this is purely a YAML configuration change within the workflow file.

Concretely:
- Edit `.github/workflows/flw.yml`.
- Insert:

  ```yaml
  permissions:
    contents: read
  ```

  after line 1 (`name: flw`) and before the `on:` block. This will satisfy CodeQL and enforce a restricted token scope while keeping the workflow behavior unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
