### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lo.yml
+++ b/.github/workflows/lo.yml
@@ -1,4 +1,6 @@
 name: lo
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/hyoklee/h5f/security/code-scanning/2](https://github.com/hyoklee/h5f/security/code-scanning/2)

To fix the problem, add an explicit `permissions:` block that grants the least privileges needed to the `GITHUB_TOKEN`. In this workflow, the job only checks out code and then runs local build/test commands; it does not create releases, modify issues, push commits, or interact with other GitHub resources. Therefore, `contents: read` is sufficient. You can define `permissions` either at the workflow root (applying to all jobs) or inside the specific job. The simplest change with minimal impact is to add a root-level `permissions:` block after the `name:` (and before `on:`), specifying `contents: read`.

Concretely, in `.github/workflows/lo.yml`, insert:

```yaml
permissions:
  contents: read
```

directly after line 1 (`name: lo`). No other imports, methods, or changes are needed because this is a GitHub Actions configuration file and the rest of the job steps remain unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
