### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lw.yml
+++ b/.github/workflows/lw.yml
@@ -1,4 +1,6 @@
 name: lw
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/hyoklee/h5f/security/code-scanning/3](https://github.com/hyoklee/h5f/security/code-scanning/3)

In general, to fix this class of problem you add an explicit `permissions` block to the workflow (top level) or to each job, granting only the minimal scopes needed. For a build-and-test workflow that only reads repository code and does not push changes, comment on PRs, or modify issues, `contents: read` is typically sufficient.

For this specific workflow in `.github/workflows/lw.yml`, the simplest and least intrusive fix is to add a `permissions` block at the root level (just under `name: lw` and before `on:`). This will apply to all jobs in the workflow (there is only one, `build`) and will limit the GITHUB_TOKEN to read-only access to repository contents. No other functionality in the shown steps depends on broader token permissions, so behavior will remain unchanged except for the reduced token scope.

Concretely:
- Edit `.github/workflows/lw.yml`.
- Insert:

  ```yaml
  permissions:
    contents: read
  ```

  after line 1 (`name: lw`) and before the existing `on:` block.
- No imports, methods, or additional definitions are required, as this is purely a YAML configuration change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
