### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lin.yml
+++ b/.github/workflows/lin.yml
@@ -8,6 +8,8 @@ jobs:
   build:
     name: lin
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - name: apt
       run: |


### PR DESCRIPTION
Potential fix for [https://github.com/hyoklee/h5f/security/code-scanning/4](https://github.com/hyoklee/h5f/security/code-scanning/4)

In general, the fix is to explicitly declare a `permissions` block that restricts the `GITHUB_TOKEN` to the least privileges required. For this workflow, all steps are local commands plus `actions/checkout`, which only needs read access to repository contents. Therefore, the safest minimal permissions are `contents: read`.

The best targeted fix without changing existing functionality is to add a `permissions` section to the `build` job, since that is the job CodeQL highlights. This keeps the scope local to the job while satisfying the requirement. Concretely, in `.github/workflows/lin.yml`, under `jobs:`, inside the `build:` job and at the same indentation level as `name:` and `runs-on:`, insert:

```yaml
    permissions:
      contents: read
```

No imports or additional methods are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
