### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lw10.yml
+++ b/.github/workflows/lw10.yml
@@ -1,5 +1,8 @@
 name: lw10
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/hyoklee/h5f/security/code-scanning/5](https://github.com/hyoklee/h5f/security/code-scanning/5)

In general, the fix is to explicitly define a `permissions:` block that restricts the `GITHUB_TOKEN` to the minimal scope required. For this workflow, the only GitHub interaction is `actions/checkout`, which needs read access to repository contents; no other write operations or special scopes are used. Therefore, we can safely set `permissions: contents: read` at the workflow root, applying to all jobs, or directly under the `build` job. Root-level permissions are simpler and match the CodeQL recommendation.

Concretely, edit `.github/workflows/lw10.yml` and add a `permissions:` block near the top of the workflow (after `name:` and before `on:`) with `contents: read`. This does not change existing functionality because `actions/checkout` continues to work with read-only contents access, and the workflow does not rely on any write scopes. No imports or additional methods are needed; this is purely a YAML configuration change within the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
