### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lwf.yml
+++ b/.github/workflows/lwf.yml
@@ -1,4 +1,6 @@
 name: lwf
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/hyoklee/h5f/security/code-scanning/6](https://github.com/hyoklee/h5f/security/code-scanning/6)

In general, to fix this category of problem you explicitly declare a `permissions:` block either at the top level of the workflow (so it applies to all jobs) or on the specific job(s) in question, specifying the minimal scopes needed. For workflows that only need to read the repository content, setting `permissions: contents: read` is typically sufficient.

For this specific workflow, the `build` job only checks out repositories and builds code; it does not appear to require any write access to the repository or other advanced scopes. The safest change that does not alter functionality is to add a minimal `permissions` block at the workflow root, immediately after the `name: lwf` line and before the `on:` block. We will set `contents: read` so that `actions/checkout` can function while ensuring the `GITHUB_TOKEN` cannot write repository contents. No additional imports or methods are needed, as this is purely a YAML configuration change within `.github/workflows/lwf.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
